### PR TITLE
feat: Added support to use library as ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+#   Allows for use with ESP-IDF and Arduino as component
+#   Tested with ESP-IDF v4.4.4
+
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(SRCS "MCP23008.cpp" 
+                       INCLUDE_DIRS "."
+                       REQUIRES arduino)
+
+project(MCP23008)


### PR DESCRIPTION
Added a CMakeLists.txt file to allow for use with ESP-IDF. Simply clone the repo into the components/ directory of an IDF project.